### PR TITLE
[forcefield] TriangularShellForceField: changes inheritance 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ sofa_find_package(Sofa.Component.Controller REQUIRED)
 sofa_find_package(Sofa.Component.Topology.Container.Dynamic REQUIRED)
 sofa_find_package(Sofa.Component.StateContainer REQUIRED)
 sofa_find_package(Sofa.Component.Mapping.Linear REQUIRED)
+sofa_find_package(Sofa.Component.SolidMechanics.FEM.Elastic REQUIRED)
 sofa_find_package(Sofa.GL REQUIRED)
 
 set(README_FILE README.md)
@@ -77,6 +78,7 @@ target_link_libraries(${PROJECT_NAME}
     Sofa.Component.Topology.Container.Dynamic
     Sofa.Component.StateContainer
     Sofa.Component.Mapping.Linear
+    Sofa.Component.SolidMechanics.FEM.Elastic
     Sofa.GL
 )
 

--- a/src/Shell/forcefield/TriangularShellForceField.h
+++ b/src/Shell/forcefield/TriangularShellForceField.h
@@ -206,8 +206,8 @@ public:
 
         sofa::core::topology::BaseMeshTopology* getTopology() {return _topology;}
 
-        using BaseLinearElasticityFEMForceField<DataTypes>::d_youngModulus;
-        using BaseLinearElasticityFEMForceField<DataTypes>::d_poissonRatio;
+        using BaseLinearElasticityFEMForceField<DataTypes>::getYoungModulusInElement;
+        using BaseLinearElasticityFEMForceField<DataTypes>::getPoissonRatioInElement;
 
         Data <Real> d_thickness;
         Data <sofa::helper::OptionsGroup> d_membraneElement;

--- a/src/Shell/forcefield/TriangularShellForceField.h
+++ b/src/Shell/forcefield/TriangularShellForceField.h
@@ -30,7 +30,7 @@
 #endif
 
 
-#include <sofa/core/behavior/ForceField.h>
+#include <sofa/component/solidmechanics/fem/elastic/BaseLinearElasticityFEMForceField.h>
 #include <sofa/core/behavior/MechanicalState.h>
 #include <sofa/core/objectmodel/Data.h>
 #include <sofa/helper/OptionsGroup.h>
@@ -57,7 +57,7 @@ namespace forcefield
 using namespace sofa::type;
 using sofa::type::vector;
 using namespace sofa::core::topology;
-using namespace sofa::core::behavior;
+using namespace sofa::component::solidmechanics::fem::elastic;
 
 /// This class can be overridden if needed for additional storage within template specializations.
 template<class DataTypes>
@@ -68,14 +68,14 @@ public:
 
 
 template<class DataTypes>
-class TriangularShellForceField : public core::behavior::ForceField<DataTypes>
+class TriangularShellForceField : public BaseLinearElasticityFEMForceField<DataTypes>
 {
     public:
-        SOFA_CLASS(SOFA_TEMPLATE(TriangularShellForceField,DataTypes), SOFA_TEMPLATE(core::behavior::ForceField,DataTypes));
+        SOFA_CLASS(SOFA_TEMPLATE(TriangularShellForceField,DataTypes), SOFA_TEMPLATE(BaseLinearElasticityFEMForceField,DataTypes));
 
-        typedef core::behavior::ForceField<DataTypes>       Inherited;
-        typedef typename DataTypes::VecCoord                VecCoord;
-        typedef typename DataTypes::VecDeriv                VecDeriv;
+        typedef BaseLinearElasticityFEMForceField<DataTypes> Inherited;
+        typedef typename DataTypes::VecCoord                 VecCoord;
+        typedef typename DataTypes::VecDeriv                 VecDeriv;
         //typedef typename DataTypes::VecReal                 VecReal;
 
         typedef typename DataTypes::Coord                   Coord;
@@ -206,8 +206,9 @@ public:
 
         sofa::core::topology::BaseMeshTopology* getTopology() {return _topology;}
 
-        Data<Real> d_poisson;
-        Data<Real> d_young;
+        using BaseLinearElasticityFEMForceField<DataTypes>::d_youngModulus;
+        using BaseLinearElasticityFEMForceField<DataTypes>::d_poissonRatio;
+
         Data <Real> d_thickness;
         Data <sofa::helper::OptionsGroup> d_membraneElement;
         Data <sofa::helper::OptionsGroup> d_bendingElement;

--- a/src/Shell/forcefield/TriangularShellForceField.inl
+++ b/src/Shell/forcefield/TriangularShellForceField.inl
@@ -73,9 +73,7 @@ void TriangularShellForceField<DataTypes>::TRQSTriangleHandler::applyCreateFunct
 // --------------------------------------------------------------------------------------
 template <class DataTypes>
 TriangularShellForceField<DataTypes>::TriangularShellForceField()
-    : d_poisson(initData(&d_poisson,(Real)0.45,"poissonRatio","Poisson ratio in Hooke's law"))
-    , d_young(initData(&d_young,(Real)3000.,"youngModulus","Young modulus in Hooke's law"))
-    , d_thickness(initData(&d_thickness,(Real)0.1,"thickness","Thickness of the plates"))
+    : d_thickness(initData(&d_thickness,(Real)0.1,"thickness","Thickness of the plates"))
     , d_membraneElement(initData(&d_membraneElement, "membraneElement", "The membrane element to use"))
     , d_bendingElement(initData(&d_bendingElement, "bendingElement", "The bending plate element to use"))
     , d_corotated(initData(&d_corotated, true, "corotated", "Compute forces in corotational frame"))
@@ -543,8 +541,8 @@ void TriangularShellForceField<DataTypes>::computeRotation(Transformation& R, co
 template <class DataTypes>
 void TriangularShellForceField<DataTypes>::computeMaterialStiffness()
 {
-    Real E = d_young.getValue(),
-        nu = d_poisson.getValue(),
+    Real E = d_youngModulus.getValue()[0],
+        nu = d_poissonRatio.getValue()[0],
         t = d_thickness.getValue();
 
     materialMatrix[0][0] = 1.0;
@@ -1157,8 +1155,9 @@ void TriangularShellForceField<DataTypes>::computeStiffnessMatrixLSTRet(Stiffnes
 template <class DataTypes>
 void TriangularShellForceField<DataTypes>::computeStiffnessMatrixAndesOpt(StiffnessMatrix &K, TriangleInformation &tinfo)
 {
-    Real beta0 = helper::rmax(0.5 - 2.0*d_poisson.getValue()*d_poisson.getValue(), 0.01);
-    return andesTemplate(K, tinfo, 3.0/2.0, AndesBeta(beta0, 1.0, 2.0, 1.0, 0.0, 1.0, -1.0, -1.0, -1.0, -2.0));
+    Real poissonRatio = d_poissonRatio.getValue()[0];
+    Real beta0 = helper::rmax(0.5 - 2.0 * poissonRatio * poissonRatio, 0.01);
+    return andesTemplate(K, tinfo, 3.0/2.0, AndesBeta{beta0, 1.0, 2.0, 1.0, 0.0, 1.0, -1.0, -1.0, -1.0, -2.0});
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

--- a/src/Shell/forcefield/TriangularShellForceField.inl
+++ b/src/Shell/forcefield/TriangularShellForceField.inl
@@ -541,8 +541,8 @@ void TriangularShellForceField<DataTypes>::computeRotation(Transformation& R, co
 template <class DataTypes>
 void TriangularShellForceField<DataTypes>::computeMaterialStiffness()
 {
-    Real E = d_youngModulus.getValue()[0],
-        nu = d_poissonRatio.getValue()[0],
+    Real E = getYoungModulusInElement(0),
+        nu = getPoissonRatioInElement(0),
         t = d_thickness.getValue();
 
     materialMatrix[0][0] = 1.0;
@@ -1129,25 +1129,25 @@ void TriangularShellForceField<DataTypes>::andesTemplate(StiffnessMatrix &K, con
 template <class DataTypes>
 void TriangularShellForceField<DataTypes>::computeStiffnessMatrixAll3I(StiffnessMatrix &K, TriangleInformation &tinfo)
 {
-    return andesTemplate(K, tinfo, 1.0, AndesBeta(4.0/9.0, 1.0/12.0, 5.0/12.0, 1.0/2.0, 0.0, 1.0/3.0, -1.0/3.0, -1.0/12.0, -1.0/2.0, -5.0/12.0));
+    return andesTemplate(K, tinfo, 1.0, AndesBeta{4.0/9.0, 1.0/12.0, 5.0/12.0, 1.0/2.0, 0.0, 1.0/3.0, -1.0/3.0, -1.0/12.0, -1.0/2.0, -5.0/12.0});
 }
 
 template <class DataTypes>
 void TriangularShellForceField<DataTypes>::computeStiffnessMatrixAll3M(StiffnessMatrix &K, TriangleInformation &tinfo)
 {
-    return andesTemplate(K, tinfo, 1.0, AndesBeta(4.0/9.0, 1.0/4.0, 5.0/4.0, 3.0/2.0, 0.0, 1.0, -1.0, -1.0/4.0, -3.0/2.0, -5.0/4.0));
+    return andesTemplate(K, tinfo, 1.0, AndesBeta{4.0/9.0, 1.0/4.0, 5.0/4.0, 3.0/2.0, 0.0, 1.0, -1.0, -1.0/4.0, -3.0/2.0, -5.0/4.0});
 }
 
 template <class DataTypes>
 void TriangularShellForceField<DataTypes>::computeStiffnessMatrixAllLS(StiffnessMatrix &K, TriangleInformation &tinfo)
 {
-    return andesTemplate(K, tinfo, 1.0, AndesBeta(4.0/9.0, 3.0/20.0, 3.0/4.0, 9.0/10.0, 0.0, 3.0/5.0, -3.0/5.0, -3.0/20.0, -9.0/10.0, -3.0/4.0));
+    return andesTemplate(K, tinfo, 1.0, AndesBeta{4.0/9.0, 3.0/20.0, 3.0/4.0, 9.0/10.0, 0.0, 3.0/5.0, -3.0/5.0, -3.0/20.0, -9.0/10.0, -3.0/4.0});
 }
 
 template <class DataTypes>
 void TriangularShellForceField<DataTypes>::computeStiffnessMatrixLSTRet(StiffnessMatrix &K, TriangleInformation &tinfo)
 {
-    return andesTemplate(K, tinfo, 4.0/3.0, AndesBeta(1.0/2.0, 2.0/3.0, -2.0/3.0, 0.0, 0.0, -4.0/3.0, 4.0/3.0, -2.0/3.0, 0.0, 2.0/3.0));
+    return andesTemplate(K, tinfo, 4.0/3.0, AndesBeta{1.0/2.0, 2.0/3.0, -2.0/3.0, 0.0, 0.0, -4.0/3.0, 4.0/3.0, -2.0/3.0, 0.0, 2.0/3.0});
 }
 
 // Optimal ANDES membrane element
@@ -1155,7 +1155,7 @@ void TriangularShellForceField<DataTypes>::computeStiffnessMatrixLSTRet(Stiffnes
 template <class DataTypes>
 void TriangularShellForceField<DataTypes>::computeStiffnessMatrixAndesOpt(StiffnessMatrix &K, TriangleInformation &tinfo)
 {
-    Real poissonRatio = d_poissonRatio.getValue()[0];
+    Real poissonRatio = getPoissonRatioInElement(0);
     Real beta0 = helper::rmax(0.5 - 2.0 * poissonRatio * poissonRatio, 0.01);
     return andesTemplate(K, tinfo, 3.0/2.0, AndesBeta{beta0, 1.0, 2.0, 1.0, 0.0, 1.0, -1.0, -1.0, -1.0, -2.0});
 }


### PR DESCRIPTION
**In this PR**:
Changes the inheritance of `TriangularShellForceField` from `ForceField` to `BaseLinearElasticityFEMForceField`.
This allow for instance to optimize the Young modulus using the `YoungModulusActuator` from SoftRobots.Inverse (see https://github.com/SofaDefrost/SoftRobots.Inverse/pull/85)

